### PR TITLE
Update peer dependencies to support ESLint v7

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "xo": "^0.30.0"
   },
   "peerDependencies": {
-    "eslint": "^6.0.0"
+    "eslint": "^6.0.0 || ^7.0.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Fixes warning I have during `npm install`:
> warning " > eslint-plugin-istanbul@0.1.1" has incorrect peer dependency "eslint@^6.0.0".